### PR TITLE
arch: fix non-injectable service dependencies (or pattern enforcement)

### DIFF
--- a/ARCH_DECISIONS.md
+++ b/ARCH_DECISIONS.md
@@ -80,16 +80,29 @@ This is the agent-layer equivalent of "Routers are HTTP-boundary-only." The extr
 
 Service classes must declare their DAOs, sub-services, integration modules, and bot provider as constructor parameters with defaults, not create them inside methods. This is what makes unit tests possible without `@patch` — tests pass mock objects directly to the constructor.
 
+**Every dependency must use the `or` injectable pattern** — no exceptions for DAOs that "always need the admin client" or integration factories like `get_email_service()`. If a dependency has no sensible default-inject path, make it keyword-only with a default of `None` and build the real instance in the `or` branch.
+
 ```python
-# Correct
+# Correct — every dependency is injectable
+class MyService:
+    def __init__(self, my_dao=None, email_service=None):
+        self.my_dao = my_dao or MyDAO()
+        self.email_service = email_service or get_email_service()
+
+# Wrong — some deps injectable, others hardwired. Hides Supabase/SES calls in tests.
 class MyService:
     def __init__(self, my_dao=None):
         self.my_dao = my_dao or MyDAO()
+        self.email_service = get_email_service()   # untestable without @patch
 
-# Wrong — hides a Supabase dependency, forces class-level patching in tests
+# Wrong — DAO created inside a method body, invisible to the constructor
 def run_something(user_id):
-    dao = MyDAO()   # untestable without @patch
+    dao = MyDAO()   # forces @patch, breaks when file is renamed
 ```
+
+**Detection:** `grep -rn "DAO()\|Service()\|get_email_service()\|get_.*_service()" services/` — any hit that is not in an `or`-branch (`x or MyDAO()`) or a `_lazy_getter` is a violation.
+
+**Test signal:** If a test calls `MyService.__new__(MyService)` to bypass `__init__`, that is a sign that the service has hardwired dependencies. Fix the service constructor instead of working around it with `__new__`.
 
 The bot provider follows the same rule. Services declare `bot_provider: BotProviderProtocol` as a constructor parameter and store it as `self._bot_provider`. No service imports or calls `get_bot_provider()` directly — that is the router's job via `Depends()`.
 

--- a/services/auth/password_reset_service.py
+++ b/services/auth/password_reset_service.py
@@ -31,12 +31,19 @@ INVALID_TOKEN_MESSAGE = "This link is invalid or expired. Please request a new o
 
 class PasswordResetService:
     """Service for handling password reset operations."""
-    
-    def __init__(self, supabase_auth_service=None) -> None:
-        self.user_dao = UserDAO()
-        self.token_dao = PasswordResetTokenDAO()
-        self.rate_limit_dao = PasswordResetRateLimitDAO()
-        self.email_service = get_email_service()
+
+    def __init__(
+        self,
+        supabase_auth_service=None,
+        user_dao=None,
+        token_dao=None,
+        rate_limit_dao=None,
+        email_service=None,
+    ) -> None:
+        self.user_dao = user_dao or UserDAO()
+        self.token_dao = token_dao or PasswordResetTokenDAO()
+        self.rate_limit_dao = rate_limit_dao or PasswordResetRateLimitDAO()
+        self.email_service = email_service or get_email_service()
         self.supabase_auth_service = supabase_auth_service or SupabaseAuthService()
     
     def request_password_reset(

--- a/services/period/period_summer_quest_service.py
+++ b/services/period/period_summer_quest_service.py
@@ -51,12 +51,20 @@ class PeriodSummerQuestService:
     so their user_id is used as the student_id for all quest and goal records.
     """
 
-    def __init__(self, *, bot_provider: BotProviderProtocol) -> None:
+    def __init__(
+        self,
+        *,
+        bot_provider: BotProviderProtocol,
+        period_dao=None,
+        ltg_goal_dao=None,
+        quest_service=None,
+        curriculum_service=None,
+    ) -> None:
         self._bot_provider = bot_provider
-        self.period_dao = PeriodDAO()
-        self.curriculum_service = CurriculumService(bot_provider=bot_provider)
-        self.ltg_goal_dao = StudentLongTermGoalDAO()
-        self.quest_service = QuestGradingService()
+        self.period_dao = period_dao or PeriodDAO()
+        self.curriculum_service = curriculum_service or CurriculumService(bot_provider=bot_provider)
+        self.ltg_goal_dao = ltg_goal_dao or StudentLongTermGoalDAO()
+        self.quest_service = quest_service or QuestGradingService()
 
     def generate_summer_quests(self, owner_id: str, period_id: str) -> dict[str, Any]:
         period = self.period_dao.get_period_by_id(period_id)


### PR DESCRIPTION
## What

`PasswordResetService` and `PeriodSummerQuestService` had multiple constructor dependencies hardwired — only one or two deps were injectable per class while the rest were always constructed unconditionally in `__init__`. This forced tests to use `PasswordResetService.__new__(PasswordResetService)` to bypass `__init__` entirely, which breaks the point of having constructor injection at all.

**`PasswordResetService`**: `user_dao`, `token_dao`, `rate_limit_dao`, and `email_service` were all hardwired. Only `supabase_auth_service` was injectable. Now all five use the `or`-injectable pattern.

**`PeriodSummerQuestService`**: `period_dao`, `ltg_goal_dao`, `quest_service`, and `curriculum_service` were all hardwired. Only `bot_provider` was injectable. Now all are injectable with defaults.

`ARCH_DECISIONS.md` updated to clarify that **every** dependency must follow the `or` pattern, including integration factories like `get_email_service()`, and to add a grep detection command and a note about `__new__` as a test smell.

## Why

Score breakdown (frequency × blast_radius × compounds_over_time):
- **frequency** = 2 (7 non-injectable deps across 2 files = 4–9 = score 2)
- **blast_radius** = 2 (spans auth and period domains)
- **compounds_over_time** = 3 (new services copy existing patterns; the half-injectable anti-pattern is a template that will spread)
- **total score = 12**

This ranked #2 after `AGENT_SERVICE_URL` redeclaration (score 27), which is being addressed separately.

## ARCH_DECISIONS change

Added to the "Services receive their dependencies" rule:
- Explicit statement that the `or` pattern is required for ALL dependencies — not just some
- A bad example showing the inconsistent half-injectable anti-pattern
- A grep detection command: `grep -rn "DAO()\|Service()\|get_email_service()" services/`
- A note that `__new__` in tests signals a missing injectable parameter

## Remaining issues (not fixed this run)

| Rank | Issue | Score |
|------|-------|-------|
| 1 | `AGENT_SERVICE_URL` redeclarated in 10 frontend route files | 27 |
| 2 | **This PR** | 12 |
| 3 | Dynamic imports inside service method bodies (`conversation_service.py:290`, `oauth_service.py:90`) | 4 |
| 4 | `period_service.py` reverse-direction import from conversation domain (tracked violation) | — |

🤖 Generated by arch-fix skill